### PR TITLE
Convert to use aws-sdk instead of right_aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 .kitchen.local.yml
 .coverage
 tmp
+.kitchen/

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -113,6 +113,8 @@ suites:
       aws_test:
         key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+        bucket: <%= ENV['AWS_S3_BUCKET'] || 'aws-test' %>
+        s3key: <%= ENV['AWS_S3_KEY'] || 'an_file' %>
 
   - name: instance_monitoring
     run_list:

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ not limited to:
 
 * [Route53](http://community.opscode.com/cookbooks/route53)
 
-**Note** This cookbook uses the `right_aws` RubyGem to interact with
-  the AWS API because at the time it was written, `fog` and `aws-sdk`
-  were not available. Further, both of those gems require `nokogiri`
-  which requires compiling native extensions, which means build tools
-  are required. We do not plan at this time to change the underlying
-  Ruby library used in order to limit the external dependencies for
-  this cookbook.
-
 Requirements
 ============
 
@@ -131,7 +123,7 @@ Recipes
 default.rb
 ----------
 
-The default recipe installs the `right_aws` RubyGem, which this
+The default recipe installs the `aws-sdk` RubyGem, which this
 cookbook requires in order to work with the EC2 API. Make sure that
 the aws recipe is in the node or role `run_list` before any resources
 from this cookbook are used.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-default['aws']['aws_sdk_version'] = "~> 2.0.10.pre"
+default['aws']['aws_sdk_version'] = "~> 2.0.22"
 default['aws']['databag_name'] = nil
 default['aws']['databag_entry'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-default['aws']['right_aws_version'] = "3.0.5"
+default['aws']['aws_sdk_version'] = "~> 2.0.10.pre"
 default['aws']['databag_name'] = nil
 default['aws']['databag_entry'] = nil

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -57,7 +57,7 @@ module Opscode
         begin
           require 'aws-sdk'
         rescue LoadError
-          Chef::Log.error("Missing gem 'right_aws'. Use the default aws recipe to install it first.")
+          Chef::Log.error("Missing gem 'aws-sdk'. Use the default aws recipe to install it first.")
         end
 
         region = instance_availability_zone

--- a/libraries/s3.rb
+++ b/libraries/s3.rb
@@ -2,11 +2,11 @@ require File.join(File.dirname(__FILE__), 'ec2')
 
 module Opscode
   module Aws
-    module Elb
+    module S3
       include Opscode::Aws::Ec2
 
-      def elb
-        @@elb ||= create_aws_interface(::Aws::ElasticLoadBalancing::Client)
+      def s3 
+        @@s3 ||= create_aws_interface(::Aws::S3::Client)
       end
     end
   end

--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -15,7 +15,7 @@ action :create do
   if nvid
     # volume id is registered in the node data, so check that the volume in fact exists in EC2
     vol = volume_by_id(nvid)
-    exists = vol && vol[:aws_status] != "deleting"
+    exists = vol && vol[:state] != "deleting"
     # TODO: determine whether this should be an error or just cause a new volume to be created. Currently erring on the side of failing loudly
     raise "Volume with id #{nvid} is registered with the node but does not exist in EC2. To clear this error, remove the ['aws']['ebs_volume']['#{new_resource.name}']['volume_id'] entry from this node's data." unless exists
   else
@@ -26,10 +26,10 @@ action :create do
     if new_resource.device && (attached_volume = currently_attached_volume(instance_id, new_resource.device))
       Chef::Log.debug("There is already a volume attached at device #{new_resource.device}")
       compatible = volume_compatible_with_resource_definition?(attached_volume)
-      raise "Volume #{attached_volume[:aws_id]} attached at #{attached_volume[:aws_device]} but does not conform to this resource's specifications" unless compatible
+      raise "Volume #{attached_volume[:volume_id]} attached at #{attached_volume[:aws_device]} but does not conform to this resource's specifications" unless compatible
       Chef::Log.debug("The volume matches the resource's definition, so the volume is assumed to be already created")
-      converge_by("update the node data with volume id: #{attached_volume[:aws_id]}") do
-        node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = attached_volume[:aws_id]
+      converge_by("update the node data with volume id: #{attached_volume[:volume_id]}") do
+        node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = attached_volume[:volume_id]
         node.save unless Chef::Config[:solo]
       end
     else
@@ -53,18 +53,21 @@ action :attach do
   # symbols, not strings.
   vol = determine_volume
 
-  if vol[:aws_status] == "in-use"
-    if vol[:aws_instance_id] != instance_id
-      raise "Volume with id #{vol[:aws_id]} exists but is attached to instance #{vol[:aws_instance_id]}"
-    else
-      Chef::Log.debug("Volume is already attached")
+  if vol[:state] == "in-use"
+    Chef::Log.info("Vol: #{vol}")
+    vol[:attachments].each do |attachment|
+      if attachment[:instance_id] != instance_id
+        raise "Volume with id #{vol[:volume_id]} exists but is attached to instance #{attachment[:instance_id]}"
+      else
+        Chef::Log.debug("Volume is already attached")
+      end
     end
   else
-    converge_by("attach the volume with aws_id=#{vol[:aws_id]} id=#{instance_id} device=#{new_resource.device} and update the node data with created volume's id") do
+    converge_by("attach the volume with aws_id=#{vol[:volume_id]} id=#{instance_id} device=#{new_resource.device} and update the node data with created volume's id") do
       # attach the volume and register its id in the node data
-      attach_volume(vol[:aws_id], instance_id, new_resource.device, new_resource.timeout)
+      attach_volume(vol[:volume_id], instance_id, new_resource.device, new_resource.timeout)
       # always use a symbol here, it is a Hash
-      node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = vol[:aws_id]
+      node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = vol[:volume_id]
       node.save unless Chef::Config[:solo]
     end
   end
@@ -72,16 +75,16 @@ end
 
 action :detach do
   vol = determine_volume
-  converge_by("detach volume with id: #{vol[:aws_id]}") do
-    detach_volume(vol[:aws_id], new_resource.timeout)
+  converge_by("detach volume with id: #{vol[:volume_id]}") do
+    detach_volume(vol[:volume_id], new_resource.timeout)
   end
 end
 
 action :snapshot do
   vol = determine_volume
-  converge_by("would create a snapshot for volume: #{vol[:aws_id]}") do
-    snapshot = ec2.create_snapshot(vol[:aws_id],new_resource.description)
-    Chef::Log.info("Created snapshot of #{vol[:aws_id]} as #{snapshot[:aws_id]}")
+  converge_by("would create a snapshot for volume: #{vol[:volume_id]}") do
+    snapshot = ec2.create_snapshot(volume_id: vol[:volume_id],description: new_resource.description)
+    Chef::Log.info("Created snapshot of #{vol[:volume_id]} as #{snapshot[:volume_id]}")
   end
 end
 
@@ -89,17 +92,17 @@ action :prune do
   vol = determine_volume
   old_snapshots = Array.new
   Chef::Log.info "Checking for old snapshots"
-  ec2.describe_snapshots.sort { |a,b| b[:aws_started_at] <=> a[:aws_started_at] }.each do |snapshot|
-    if snapshot[:aws_volume_id] == vol[:aws_id]
-      Chef::Log.info "Found old snapshot #{snapshot[:aws_id]} (#{snapshot[:aws_volume_id]}) #{snapshot[:aws_started_at]}"
+  ec2.describe_snapshots[:snapshots].sort { |a,b| b[:start_time] <=> a[:start_time] }.each do |snapshot|
+    if snapshot[:volume_id] == vol[:volume_id]
+      Chef::Log.info "Found old snapshot #{snapshot[:volume_id]} (#{snapshot[:volume_id]}) #{snapshot[:start_time]}"
       old_snapshots << snapshot
     end
   end
   if old_snapshots.length > new_resource.snapshots_to_keep
     old_snapshots[new_resource.snapshots_to_keep, old_snapshots.length].each do |die|
-      converge_by("delete snapshot with id: #{die[:aws_id]}") do
-        Chef::Log.info "Deleting old snapshot #{die[:aws_id]}"
-        ec2.delete_snapshot(die[:aws_id])
+      converge_by("delete snapshot with id: #{die[:snapshot_id]}") do
+        Chef::Log.info "Deleting old snapshot #{die[:snapshot_id]}"
+        ec2.delete_snapshot(snapshot_id: die[:snapshot_id])
       end
     end
   end
@@ -118,7 +121,7 @@ end
 # Pulls the volume id from the volume_id attribute or the node data and verifies that the volume actually exists
 def determine_volume
   vol = currently_attached_volume(instance_id, new_resource.device)
-  vol_id = new_resource.volume_id || volume_id_in_node_data || ( vol ? vol[:aws_id] : nil )
+  vol_id = new_resource.volume_id || volume_id_in_node_data || ( vol ? vol[:volume_id] : nil )
   raise "volume_id attribute not set and no volume id is set in the node data for this resource (which is populated by action :create) and no volume is attached at the device" unless vol_id
 
   # check that volume exists
@@ -130,12 +133,14 @@ end
 
 # Retrieves information for a volume
 def volume_by_id(volume_id)
-  ec2.describe_volumes.find{|v| v[:aws_id] == volume_id}
+  ec2.describe_volumes[:volumes].find{|v| v[:volume_id] == volume_id}
 end
 
 # Returns the volume that's attached to the instance at the given device or nil if none matches
 def currently_attached_volume(instance_id, device)
-  ec2.describe_volumes.find{|v| v[:aws_instance_id] == instance_id && v[:aws_device] == device}
+  ec2.describe_volumes[:volumes].find do |v| 
+      v[:attachments].any? {|a| a[:device] == device && a[:instance_id] == instance_id}
+  end
 end
 
 # Returns true if the given volume meets the resource's attributes
@@ -143,7 +148,7 @@ def volume_compatible_with_resource_definition?(volume)
   if new_resource.snapshot_id =~ /vol/
     new_resource.snapshot_id(find_snapshot_id(new_resource.snapshot_id, new_resource.most_recent_snapshot))
   end
-  (new_resource.size.nil? || new_resource.size == volume[:aws_size]) &&
+  (new_resource.size.nil? || new_resource.size == volume[:size]) &&
   (new_resource.availability_zone.nil? || new_resource.availability_zone == volume[:zone]) &&
   (new_resource.snapshot_id.nil? || new_resource.snapshot_id == volume[:snapshot_id])
 end
@@ -155,9 +160,11 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
   # Sanity checks so we don't shoot ourselves.
   raise "Invalid volume type: #{volume_type}" unless ['standard', 'io1', 'gp2'].include?(volume_type)
 
+  params = {availability_zone: availability_zone, volume_type: volume_type}
   # PIOPs requested. Must specify an iops param and probably won't be "low".
   if volume_type == 'io1'
     raise 'IOPS value not specified.' unless piops >= 100
+    params[:iops] = piops
   end
 
   # Shouldn't see non-zero piops param without appropriate type.
@@ -165,28 +172,30 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
     raise 'IOPS param without piops volume type.' unless volume_type == 'io1'
   end
 
-  create_volume_opts = { :volume_type => volume_type }
-  # TODO: this may have to be casted to a string.  rightaws vs aws doc discrepancy.
-  create_volume_opts[:iops] = piops if volume_type == 'io1'
+  if snapshot_id
+      params[:snapshot_id] = snapshot_id
+  else
+      params[:size] = size
+  end
 
-  nv = ec2.create_volume(snapshot_id, size, availability_zone, create_volume_opts)
-  Chef::Log.debug("Created new volume #{nv[:aws_id]}#{snapshot_id ? " based on #{snapshot_id}" : ""}")
+  nv = ec2.create_volume(params)
+  Chef::Log.debug("Created new volume #{nv[:volume_id]}#{snapshot_id ? " based on #{snapshot_id}" : ""}")
 
   # block until created
   begin
     Timeout::timeout(timeout) do
       while true
-        vol = volume_by_id(nv[:aws_id])
-        if vol && vol[:aws_status] != "deleting"
-          if ["in-use", "available"].include?(vol[:aws_status])
-            Chef::Log.info("Volume #{nv[:aws_id]} is available")
+        vol = volume_by_id(nv[:volume_id])
+        if vol && vol[:state] != "deleting"
+          if ["in-use", "available"].include?(vol[:state])
+            Chef::Log.info("Volume #{nv[:volume_id]} is available")
             break
           else
-            Chef::Log.debug("Volume is #{vol[:aws_status]}")
+            Chef::Log.debug("Volume is #{vol[:state]}")
           end
           sleep 3
         else
-          raise "Volume #{nv[:aws_id]} no longer exists"
+          raise "Volume #{nv[:volume_id]} no longer exists"
         end
       end
     end
@@ -194,29 +203,30 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
     raise "Timed out waiting for volume creation after #{timeout} seconds"
   end
 
-  nv[:aws_id]
+  nv[:volume_id]
 end
 
 # Attaches the volume and blocks until done (or times out)
 def attach_volume(volume_id, instance_id, device, timeout)
   Chef::Log.debug("Attaching #{volume_id} as #{device}")
-  ec2.attach_volume(volume_id, instance_id, device)
+  ec2.attach_volume(volume_id: volume_id, instance_id: instance_id, device: device)
 
   # block until attached
   begin
     Timeout::timeout(timeout) do
       while true
         vol = volume_by_id(volume_id)
-        if vol && vol[:aws_status] != "deleting"
-          if vol[:aws_attachment_status] == "attached"
-            if vol[:aws_instance_id] == instance_id
+        if vol && vol[:state] != "deleting"
+          attachment = vol[:attachments].find{|a| a[:state] == "attached"}
+          if attachment != nil
+            if attachment[:instance_id] == instance_id
               Chef::Log.info("Volume #{volume_id} is attached to #{instance_id}")
               break
             else
               raise "Volume is attached to instance #{vol[:aws_instance_id]} instead of #{instance_id}"
             end
           else
-            Chef::Log.debug("Volume is #{vol[:aws_status]}")
+            Chef::Log.debug("Volume is #{vol[:state]}")
           end
           sleep 3
         else
@@ -232,21 +242,21 @@ end
 # Detaches the volume and blocks until done (or times out)
 def detach_volume(volume_id, timeout)
   vol = volume_by_id(volume_id)
-  if vol[:aws_instance_id] != instance_id
-    Chef::Log.debug("EBS Volume #{volume_id} is not attached to this instance (attached to #{vol[:aws_instance_id]}). Skipping...")
+  if vol[:instance_id] != instance_id
+    Chef::Log.debug("EBS Volume #{volume_id} is not attached to this instance (attached to #{vol[:instance_id]}). Skipping...")
     return
   end
   Chef::Log.debug("Detaching #{volume_id}")
-  orig_instance_id = vol[:aws_instance_id]
-  ec2.detach_volume(volume_id)
+  orig_instance_id = vol[:instance_id]
+  ec2.detach_volume(volume_id: volume_id)
 
   # block until detached
   begin
     Timeout::timeout(timeout) do
       while true
         vol = volume_by_id(volume_id)
-        if vol && vol[:aws_status] != "deleting"
-          if vol[:aws_instance_id] != orig_instance_id
+        if vol && vol[:state] != "deleting"
+          if vol[:instance_id] != orig_instance_id
             Chef::Log.info("Volume detached from #{orig_instance_id}")
             break
           else
@@ -263,5 +273,3 @@ def detach_volume(volume_id, timeout)
     raise "Timed out waiting for volume detachment after #{timeout} seconds"
   end
 end
-
-

--- a/providers/elastic_ip.rb
+++ b/providers/elastic_ip.rb
@@ -45,7 +45,7 @@ action :allocate do
     Chef::Log.info("An Elastic IP was already allocated for #{new_resource.name} #{current_elastic_ip} from the instance")
   else
     converge_by("allocate new Elastic IP for #{new_resource.name}") do
-      addr = ec2.allocate_address
+      addr = ec2.allocate_address(:domain => new_resource.domain)
       Chef::Log.info("Allocated Elastic IP #{addr[:public_ip]} from the instance")
       node.set['aws']['elastic_ip'][new_resource.name]['ip'] = addr[:public_ip]
       node.save unless Chef::Config[:solo]
@@ -56,15 +56,15 @@ end
 private
 
 def address(ip)
-  ec2.describe_addresses.find { |a| a[:public_ip] == ip }
+  ec2.describe_addresses[:addresses].find { |a| a[:public_ip] == ip }
 end
 
 def attach(ip, timeout)
   addr = address(ip)
   if addr[:domain] == 'vpc'
-    ec2.associate_address(instance_id, {:allocation_id => addr[:allocation_id]})
+    ec2.associate_address(instance_id: instance_id, allocation_id: addr[:allocation_id])
   else
-    ec2.associate_address(instance_id, {:public_ip => addr[:public_ip]})
+    ec2.associate_address(instance_id: instance_id, public_ip: addr[:public_ip])
   end
 
   # block until attached
@@ -89,7 +89,12 @@ def attach(ip, timeout)
 end
 
 def detach(ip, timeout)
-  ec2.disassociate_address({:public_ip => ip})
+  addr = address(ip)
+  if ip[:domain] == 'vpc'
+    ec2.disassociate_address(allocation_ip: addr[:allocation_id])
+  else
+    ec2.disassociate_address(public_ip: ip)
+  end
 
   # block until detached
   begin

--- a/providers/elastic_lb.rb
+++ b/providers/elastic_lb.rb
@@ -2,10 +2,10 @@ include Opscode::Aws::Elb
 
 action :register do
   converge_by("add the node #{new_resource.name} to ELB") do
-    target_lb = elb.describe_load_balancers.find {|lb| lb[:load_balancer_name] == new_resource.name }
+    target_lb = elb.describe_load_balancers[:load_balancer_descriptions].find {|lb| lb[:load_balancer_name] == new_resource.name }
     unless target_lb[:instances].include?(instance_id)
       Chef::Log.info("Adding node to ELB #{new_resource.name}")
-      elb.register_instances_with_load_balancer(new_resource.name, instance_id)
+      elb.register_instances_with_load_balancer(load_balancer_name: new_resource.name, instances: [{instance_id: instance_id}])
     else
       Chef::Log.debug("Node #{instance_id} is already present in ELB instances, no action required.")
     end
@@ -14,10 +14,10 @@ end
 
 action :deregister do
   converge_by("remove the node #{new_resource.name} from ELB") do
-    target_lb = elb.describe_load_balancers.find {|lb| lb[:load_balancer_name] == new_resource.name }
+    target_lb = elb.describe_load_balancers[:load_balancer_descriptions].find {|lb| lb[:load_balancer_name] == new_resource.name }
     if target_lb[:instances].include?(instance_id)
       Chef::Log.info("Removing node from ELB #{new_resource.name}")
-      elb.deregister_instances_with_load_balancer(new_resource.name, instance_id)
+      elb.deregister_instances_with_load_balancer(load_balancer_name: new_resource.name, instances: [{instance_id: instance_id}])
     else
       Chef::Log.debug("Node #{instance_id} is not present in ELB instances, no action required.")
     end

--- a/providers/instance_monitoring.rb
+++ b/providers/instance_monitoring.rb
@@ -10,7 +10,7 @@ action :enable do
   else
     converge_by("enable monitoring for this instance") do
       Chef::Log.info("Enabling monitoring for this instance")
-      ec2.monitor_instances(instance_id)
+      ec2.monitor_instances(instance_ids: [instance_id])
     end
   end
 end
@@ -19,7 +19,7 @@ action :disable do
   if is_monitoring_enabled
     converge_by("disable monitoring for this instance") do
       Chef::Log.info("Disabling monitoring for this instance")
-      ec2.unmonitor_instances(instance_id)
+      ec2.unmonitor_instances(instance_ids: [instance_id])
     end
   else
     Chef::Log.debug("Monitoring is already disabled for this instance")
@@ -29,7 +29,7 @@ end
 private
 
 def is_monitoring_enabled()
-  monitoring_state = ec2.describe_instances(instance_id)[0][:monitoring_state]
+  monitoring_state = ec2.describe_instances(instance_ids: [instance_id])[:reservations][0][:instances][0][:monitoring][:state]
   Chef::Log.info("Current monitoring state for this instance is #{monitoring_state}")
   return monitoring_state == "enabled"
 end

--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -31,7 +31,14 @@ def do_s3_file(resource_action)
   remote_path = new_resource.remote_path
   remote_path.sub!(/^\/*/, "")
 
-  s3url = RightAws::S3Interface.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key).get_link(new_resource.bucket, remote_path)
+
+  if new_resource.aws_access_key_id and new_resource.aws_secret_access_key
+    s3url = RightAws::S3Interface.new(new_resource.aws_access_key_id, new_resource.aws_secret_access_key).get_link(new_resource.bucket, remote_path)
+  else
+    creds = query_role_credentials
+    s3url = RightAws::S3Interface.new(creds['AccessKeyId'], creds['SecretAccessKey'], 
+                                     {:logger => Chef::Log, :region => region, :token => creds['Token']}).get_link(new_resource.bucket, remote_path)
+  end
 
   remote_file new_resource.name do
     path new_resource.path

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 chef_gem "aws-sdk" do
-  version '2.0.9.pre'
+  version node['aws']['aws_sdk_version']
   action :install
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,10 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-chef_gem "right_aws" do
-  version node['aws']['right_aws_version']
+chef_gem "aws-sdk" do
+  version '2.0.9.pre'
   action :install
 end
 
-require 'right_aws'
+require 'aws-sdk'

--- a/resources/s3_file.rb
+++ b/resources/s3_file.rb
@@ -14,6 +14,7 @@ attribute :path, :kind_of => String, :name_attribute => true
 attribute :remote_path, :kind_of => String
 attribute :bucket, :kind_of => String
 attribute :aws_access_key_id, :kind_of => String
+attribute :aws_access_key, :kind_of => String
 attribute :aws_secret_access_key, :kind_of => String
 attribute :owner, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
@@ -39,4 +40,14 @@ def initialize(*args)
   super
   @action = :create
   @path = name
+  @aws_access_key = @aws_access_key_id #Fix inconsistency in naming
+end
+
+# Fix inconsistency in naming
+def aws_access_key( arg=nil ) 
+  if arg.nil? and @aws_access_key.nil?
+    @aws_access_key_id
+  else
+    set_or_return( :aws_access_key, arg, :kind_of => String )
+  end
 end

--- a/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
+++ b/test/fixtures/cookbooks/aws_test/recipes/s3_file.rb
@@ -1,8 +1,8 @@
 include_recipe 'aws'
 
 aws_s3_file "/tmp/an_file" do
-  bucket "aws-cookbook"
-  remote_path "an_file"
+  bucket node['aws_test']['bucket']
+  remote_path node['aws_test']['s3key']
   aws_access_key_id node['aws_test']['key_id']
   aws_secret_access_key node['aws_test']['access_key']
 end


### PR DESCRIPTION
This converts all providers to use aws-sdk.  This allows S3 to use the iam-profile and opens up other options as aws-sdk supports a much larger range of aws services.