### PR TITLE
only set compile_time on chef_gem if supported

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 chef_gem 'aws-sdk' do
   version node['aws']['aws_sdk_version']
-  compile_time true
+  compile_time true  if respond_to?(:compile_time)
   action :install
 end
 


### PR DESCRIPTION
check that the resource responds to the compile_time attribute to avoid breaking with older chef. 