### PR TITLE
[test me] compile_time works with Chef 11/12 including chef-sugar

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@
 #
 chef_gem 'aws-sdk' do
   version node['aws']['aws_sdk_version']
+  compile_time true if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
   action :install
 end
 


### PR DESCRIPTION
The test recipe is the following (please note that this is the patched aws from this PR, with a little difference to trigger warning, see below):

```ruby
include_recipe 'chef-sugar'
include_recipe 'aws'
```

`chef_gem` patched code (`compile_time` is not set to anything to trigger the warning):

```ruby
chef_gem 'aws-sdk' do
  version node['aws']['aws_sdk_version']
  if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
    compile_time
  end
  action :install
end
```

Here are my results:

Chef **12.1.0.dev.0**, without specifying `true`, just `compile_time` to show the warning :

```
==> zs1: [2015-02-19T06:47:57+00:00] INFO: Forking chef instance to converge...
==> zs1: [2015-02-19T06:47:57+00:00] INFO: *** Chef 12.1.0.dev.0 ***
==> zs1: [2015-02-19T06:47:57+00:00] INFO: Chef-client pid: 14440
==> zs1: [2015-02-19T06:48:15+00:00] WARN: chef_gem[chef-sugar] chef_gem compile_time installation is deprecated
==> zs1: [2015-02-19T06:48:15+00:00] WARN: chef_gem[chef-sugar] Please set `compile_time false` on the resource to use the new behavior.
==> zs1: [2015-02-19T06:48:15+00:00] WARN: chef_gem[chef-sugar] or set `compile_time true` on the resource if compile_time behavior is required.
==> zs1: [2015-02-19T06:48:23+00:00] INFO: chef_gem[chef-sugar] installed chef-sugar at 2.5.0
==> zs1: [2015-02-19T06:48:23+00:00] WARN: chef_gem[aws-sdk] chef_gem compile_time installation is deprecated
==> zs1: [2015-02-19T06:48:23+00:00] WARN: chef_gem[aws-sdk] Please set `compile_time false` on the resource to use the new behavior.
==> zs1: [2015-02-19T06:48:23+00:00] WARN: chef_gem[aws-sdk] or set `compile_time true` on the resource if compile_time behavior is required.
==> zs1: [2015-02-19T06:48:31+00:00] INFO: chef_gem[aws-sdk] installed aws-sdk at ~> 2.0.22
==> zs1: [2015-02-19T06:48:32+00:00] INFO: Chef Run complete in 28.265871351 seconds
```

Chef **12.0.3**, don't see any log, but both gems are installed:

```
==> zs1: [2015-02-19T06:53:56+00:00] INFO: *** Chef 12.0.3 ***
==> zs1: [2015-02-19T06:53:56+00:00] INFO: Chef-client pid: 14938
==> zs1: [2015-02-19T06:54:24+00:00] INFO: Chef Run complete in 20.955133524 seconds
```

```
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep chef
chef (12.0.3)
chef-sugar (2.5.0)
chef-zero (3.2.1)
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep aws
aws-sdk (2.0.26)
aws-sdk-core (2.0.26)
aws-sdk-resources (2.0.26)
```

Chef **11.16.4**, don't see any log, but both gems are installed:

```
==> zs1: [2015-02-19T06:56:38+00:00] INFO: *** Chef 11.16.4 ***
==> zs1: [2015-02-19T06:56:38+00:00] INFO: Chef-client pid: 15433
==> zs1: /var/chef/cache/cookbooks/homebrew/libraries/homebrew_package.rb:26: warning: toplevel constant Homebrew referenced by Chef::Provider::Package::Homebrew
==> zs1: [2015-02-19T06:57:47+00:00] INFO: Chef Run complete in 25.402963436 seconds
```

```
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep chef
chef (11.16.4)
chef-sugar (2.5.0)
chef-zero (2.2)
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep aws
aws-sdk (2.0.26)
aws-sdk-core (2.0.26)
aws-sdk-resources (2.0.26)
```

Chef **11.18.6**, don't see any log, but both gems are installed:

```
==> zs1: [2015-02-19T06:58:47+00:00] INFO: *** Chef 11.18.6 ***
==> zs1: [2015-02-19T06:58:47+00:00] INFO: Chef-client pid: 16297
==> zs1: /var/chef/cache/cookbooks/homebrew/libraries/homebrew_package.rb:26: warning: toplevel constant Homebrew referenced by Chef::Provider::Package::Homebrew
==> zs1: [2015-02-19T06:59:22+00:00] INFO: Chef Run complete in 27.925290915 seconds
```

```
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep chef
chef (11.18.6)
chef-sugar (2.5.0)
chef-zero (2.2.1)
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep aws
aws-sdk (2.0.26)
aws-sdk-core (2.0.26)
aws-sdk-resources (2.0.26)
```

I also tried with `chef_12.2.0-alpha.0-1_amd64.deb` (which does not support `compile_time`):

```
==> zs1: [2015-02-19T07:00:55+00:00] INFO: *** Chef 12.2.0.alpha.0 ***
==> zs1: [2015-02-19T07:00:55+00:00] INFO: Chef-client pid: 16759
==> zs1: [2015-02-19T07:01:41+00:00] INFO: Starting audit phase
==> zs1: [2015-02-19T07:01:42+00:00] INFO: Successfully executed all controls blocks and contained examples
==> zs1:
==> zs1: Finished in 0.00018 seconds (files took 0.35235 seconds to load)
==> zs1: 0 examples, 0 failures
==> zs1: [2015-02-19T07:01:42+00:00] INFO: Chef Run complete in 39.759534584 seconds
```

```
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep chef
chef (12.2.0.alpha.0)
chef-sugar (2.5.0)
chef-zero (3.2)
root@mesosphere-scalp-vagrant-vbox-1:~# /opt/chef/embedded/bin/gem list | grep aws
aws-sdk (2.0.26)
aws-sdk-core (2.0.26)
aws-sdk-resources (2.0.26)
```

I'm mostly breaking "something" as I don't see the resource being listed in the log but hopefully it helps.