### PR TITLE
support encrypted EBS volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ during the Compile Phase of the Chef run.
 ec2_hints.rb
 ------------
 
-This recipe is used to setup the ec2 hints for ohai in the case that an 
+This recipe is used to setup the ec2 hints for ohai in the case that an
 instance is not created using knife-ec2.
 
 Libraries
@@ -192,6 +192,8 @@ Attribute Parameters:
 * `volume_type` - "standard", "io1", or "gp2" ("standard" is magnetic, "io1" is piops SSD, "gp2" is general purpose SSD)
 * `piops` - number of Provisioned IOPS to provision, must be >= 100
 * `existing_raid` - whether or not to assume the raid was previously assembled on existing volumes (default no)
+* `encrypted` - specify if the EBS should be encrypted
+* `kms_key_id` - the full ARN of the AWS Key Management Service (AWS KMS) master key to use when creating the encrypted volume (defaults to master key if not specified)
 
 ## ebs_raid.rb
 

--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -41,7 +41,8 @@ action :create do
                              new_resource.timeout,
                              new_resource.volume_type,
                              new_resource.piops,
-                             new_resource.encrypted)
+                             new_resource.encrypted,
+                             new_resource.kms_key_id)
         node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = nvid
         node.save unless Chef::Config[:solo]
       end
@@ -153,13 +154,13 @@ def volume_compatible_with_resource_definition?(volume)
 end
 
 # Creates a volume according to specifications and blocks until done (or times out)
-def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, piops, encrypted)
+def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, piops, encrypted, kms_key_id)
   availability_zone ||= instance_availability_zone
 
   # Sanity checks so we don't shoot ourselves.
   fail "Invalid volume type: #{volume_type}" unless %w(standard io1 gp2).include?(volume_type)
 
-  params = { availability_zone: availability_zone, volume_type: volume_type, encrypted: encrypted }
+  params = { availability_zone: availability_zone, volume_type: volume_type, encrypted: encrypted, kms_key_id: kms_key_id }
   # PIOPs requested. Must specify an iops param and probably won't be "low".
   if volume_type == 'io1'
     fail 'IOPS value not specified.' unless piops >= 100
@@ -178,7 +179,7 @@ def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, pi
   end
 
   nv = ec2.create_volume(params)
-  Chef::Log.debug("Created new volume #{nv[:volume_id]}#{snapshot_id ? " based on #{snapshot_id}" : ''}")
+  Chef::Log.debug("Created new #{nv[:encrypted] ? 'encryped' : ''} volume #{nv[:volume_id]}#{snapshot_id ? " based on #{snapshot_id}" : ''}")
 
   # block until created
   begin

--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -113,7 +113,7 @@ private
 
 def volume_id_in_node_data
   node['aws']['ebs_volume'][new_resource.name]['volume_id']
-rescue NoMethodError => e
+rescue NoMethodError
   nil
 end
 

--- a/providers/ebs_volume.rb
+++ b/providers/ebs_volume.rb
@@ -40,7 +40,8 @@ action :create do
                              new_resource.availability_zone,
                              new_resource.timeout,
                              new_resource.volume_type,
-                             new_resource.piops)
+                             new_resource.piops,
+                             new_resource.encrypted)
         node.set['aws']['ebs_volume'][new_resource.name]['volume_id'] = nvid
         node.save unless Chef::Config[:solo]
       end
@@ -152,13 +153,13 @@ def volume_compatible_with_resource_definition?(volume)
 end
 
 # Creates a volume according to specifications and blocks until done (or times out)
-def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, piops)
+def create_volume(snapshot_id, size, availability_zone, timeout, volume_type, piops, encrypted)
   availability_zone ||= instance_availability_zone
 
   # Sanity checks so we don't shoot ourselves.
   fail "Invalid volume type: #{volume_type}" unless %w(standard io1 gp2).include?(volume_type)
 
-  params = { availability_zone: availability_zone, volume_type: volume_type }
+  params = { availability_zone: availability_zone, volume_type: volume_type, encrypted: encrypted }
   # PIOPs requested. Must specify an iops param and probably won't be "low".
   if volume_type == 'io1'
     fail 'IOPS value not specified.' unless piops >= 100

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -28,6 +28,7 @@ attribute :snapshots_to_keep,     default: 2
 attribute :volume_type,           kind_of: String, default: 'standard'
 attribute :piops,                 kind_of: Integer, default: 0
 attribute :encrypted,             kind_of: [TrueClass, FalseClass], default: false
+attribute :kms_key_id,            kind_of: String
 
 def initialize(*args)
   super

--- a/resources/ebs_volume.rb
+++ b/resources/ebs_volume.rb
@@ -11,7 +11,8 @@ state_attrs :availability_zone,
             :snapshots_to_keep,
             :timeout,
             :volume_id,
-            :volume_type
+            :volume_type,
+            :encrypted
 
 attribute :aws_access_key,        kind_of: String
 attribute :aws_secret_access_key, kind_of: String
@@ -26,6 +27,7 @@ attribute :timeout,               default: 3 * 60 # 3 mins, nil or 0 for no time
 attribute :snapshots_to_keep,     default: 2
 attribute :volume_type,           kind_of: String, default: 'standard'
 attribute :piops,                 kind_of: Integer, default: 0
+attribute :encrypted,             kind_of: [TrueClass, FalseClass], default: false
 
 def initialize(*args)
   super


### PR DESCRIPTION
I remember seeing PRs related to the `right_aws` gem, so this is for `aws-sdk` one, now that we don't depend on the old one anymore.

Per:

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html

and

http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#create_volume-instance_method