### PR TITLE
Improvement of resource_tag id regex.

### DIFF
--- a/resources/resource_tag.rb
+++ b/resources/resource_tag.rb
@@ -11,5 +11,5 @@ state_attrs :aws_access_key,
 
 attribute :aws_access_key, kind_of: String
 attribute :aws_secret_access_key, kind_of: String
-attribute :resource_id,  kind_of: [String, Array], regex: /(i|snap|vol)-[a-zA-Z0-9]+/
+attribute :resource_id,  kind_of: [String, Array], regex: /(i|snap|vol)-[a-fA-F0-9]{8}/
 attribute :tags, kind_of: Hash, required: true


### PR DESCRIPTION
Wanted this regex to be 100% compliant with AWS resource ids.
Obvious fix.