### PR TITLE
Make compatible with older versions of Chef (before version 12)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,5 @@ description 'LWRPs for managing AWS resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '2.7.0'
 recipe 'aws', 'Installs the right_aws gem during compile time'
-source_url       "https://github.com/opscode-cookbooks/aws"
-issues_url       "https://github.com/opscode-cookbooks/aws/issues"
+source_url "https://github.com/opscode-cookbooks/aws" if respond_to?(:source_url)
+issues_url "https://github.com/opscode-cookbooks/aws/issues" if respond_to?(:issues_url)


### PR DESCRIPTION
On Chef 11, using Berkshelf, you'd get this error:
```
Ridley::Errors::FromFileParserError Could not parse `/var/folders/cl/j95g29yd7v9gk8cvw559drnw0000gp/T/d20150407-97011-tbywhu/metadata.rb': undefined method `source_url' for #<Ridley::Chef::Cookbook::Metadata:0x000001012ef4a8>
```