### PR TITLE
Updated to copy over sensitive attribute as well

### DIFF
--- a/providers/s3_file.rb
+++ b/providers/s3_file.rb
@@ -45,6 +45,7 @@ def do_s3_file(resource_action)
       inherits new_resource.inherits
       rights new_resource.rights
     end
+    sensitive new_resource.sensitive
     action resource_action
 
     if version.major > 11 || (version.major == 11 && version.minor >= 6)


### PR DESCRIPTION
I'm saving secrets in files in s3 bucket and when I copy over the files to my server using aws_s3_file,  chef displays content of files in chef run log. Setting sensitive attribute to true prevents this but the attribute is not passed over. This pull request fixes it.