### PR TITLE
Elastic lb provider fix - does not run deregister, always tries to register

### DIFF
--- a/providers/elastic_lb.rb
+++ b/providers/elastic_lb.rb
@@ -17,7 +17,7 @@ action :deregister do
     target_lb = elb.describe_load_balancers[:load_balancer_descriptions].find { |lb| lb[:load_balancer_name] == new_resource.name }
     if target_lb[:instances].detect { |instances| instances.include?(instance_id) }
       Chef::Log.info("Removing node from ELB #{new_resource.name}")
-      elb.deregister_instances_with_load_balancer(load_balancer_name: new_resource.name, instances: [{ instance_id: instance_id }])
+      elb.deregister_instances_from_load_balancer(load_balancer_name: new_resource.name, instances: [{ instance_id: instance_id }])
     else
       Chef::Log.debug("Node #{instance_id} is not present in ELB instances, no action required.")
     end

--- a/providers/elastic_lb.rb
+++ b/providers/elastic_lb.rb
@@ -3,7 +3,7 @@ include Opscode::Aws::Elb
 action :register do
   converge_by("add the node #{new_resource.name} to ELB") do
     target_lb = elb.describe_load_balancers[:load_balancer_descriptions].find { |lb| lb[:load_balancer_name] == new_resource.name }
-    unless target_lb[:instances].include?(instance_id)
+    unless target_lb[:instances].detect { |instances| instances.include?(instance_id) }
       Chef::Log.info("Adding node to ELB #{new_resource.name}")
       elb.register_instances_with_load_balancer(load_balancer_name: new_resource.name, instances: [{ instance_id: instance_id }])
     else
@@ -15,7 +15,7 @@ end
 action :deregister do
   converge_by("remove the node #{new_resource.name} from ELB") do
     target_lb = elb.describe_load_balancers[:load_balancer_descriptions].find { |lb| lb[:load_balancer_name] == new_resource.name }
-    if target_lb[:instances].include?(instance_id)
+    if target_lb[:instances].detect { |instances| instances.include?(instance_id) }
       Chef::Log.info("Removing node from ELB #{new_resource.name}")
       elb.deregister_instances_with_load_balancer(load_balancer_name: new_resource.name, instances: [{ instance_id: instance_id }])
     else


### PR DESCRIPTION
See issue: https://github.com/opscode-cookbooks/aws/issues/132

This allows the deregister action to actually run and prevents the register action from running if the node is currently in the ELB.