### PR TITLE
Make ebs_raid resource usable without a `snapshots` attribute

### DIFF
--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -345,7 +345,7 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
       device "/dev/#{disk_dev_path}"
       name disk_dev_path
       action [:create, :attach]
-      snapshot_id creating_from_snapshot ? snapshots[i - 1] : ''
+      snapshot_id creating_from_snapshot ? snapshots[i - 1] : nil
       provider 'aws_ebs_volume'
 
       # set up our data bag info


### PR DESCRIPTION
The fix is simple: change empty value for `snapshot_id` from `''` to `nil`.

Before this change, using the ebs_raid resource without a `snapshots` attribute produced the following error:
> Aws::EC2::Errors::MissingParameter
> The request must contain the parameter size/snapshot

I plucked this out of #130 since it's the minimum change required to make `ebs_raid` usable again. The encryption stuff is great, but orthogonal to this fix.

Fixes #118.