### PR TITLE
use correct Berksfile syntax

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site 'https://supermarket.chef.io'
+source 'https://supermarket.chef.io'
 
 metadata
 


### PR DESCRIPTION
Introduced in 7a77332ca052a323880d91c3174cef1311ad7ad3

Running with `site` triggers error, see
https://github.com/berkshelf/berkshelf/wiki/deprecated-locations